### PR TITLE
Fixed build script on windows (and possibly mac)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,10 +9,14 @@ fn main() {
 	println!("cargo:rerun-if-changed={SRC_THEMES_DIR}");
 
 	let themes_dir = {
-		let Some(data) = dirs::state_dir() else {
-			eprintln!("No Data directory could be found/accessed!");
-			panic!("Failed to find Data directory.")
-		};
+		let data = dirs::state_dir().unwrap_or({
+			let home = dirs::home_dir().unwrap();
+			let state = home.join(".local").join("state");
+			if !state.exists() {
+				fs::create_dir_all(&state).expect("Failed to create a Data/State directory.");
+			}
+			state
+		});
 		let app_data_dir = data.join(APP_DATA_DIR);
 
 		let themes_dir = app_data_dir.join("Themes");

--- a/src/data/io.rs
+++ b/src/data/io.rs
@@ -63,10 +63,7 @@ use tokio::{
 /// Initializes log4rs with custom configuration for stdout and file logging.
 pub fn logger_init() {
 	let log_file_path = {
-		let Some(state) = dirs::state_dir() else {
-			log::error!("No App State directory could be found/accessed!");
-			panic!("Failed to find App State directory.")
-		};
+		let state = get_state_directory();
 		let log_dir = state.join(APP_DATA_DIR);
 
 		if let Err(e) = fs::create_dir_all(&log_dir) {
@@ -138,6 +135,19 @@ pub fn get_userdata_path() -> PathBuf {
 	let userdata_dir = get_config_dir();
 	fs::create_dir_all(&userdata_dir).expect("Could not create Rhyolite config directory");
 	userdata_dir.join(USER_DATA_FILE)
+}
+
+/// This function is used to get or generate a state directory.
+pub fn get_state_directory() -> PathBuf {
+	dirs::state_dir().unwrap_or({
+		let home = dirs::home_dir().unwrap();
+		let state = home.join(".local").join("state");
+		if !state.exists() {
+		    // Panics only when it failed to create one
+			fs::create_dir_all(&state).expect("Failed to create a Data/State directory.");
+		}
+		state
+	})
 }
 
 /// Generate a path that is not conflicting by incrementing a counter at the file end

--- a/src/data/themes.rs
+++ b/src/data/themes.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::data::types::APP_DATA_DIR;
+use crate::data::io::get_state_directory;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -28,10 +29,7 @@ impl ThemesStore {
 	// TODO: Make this as new function and make a new default function.
 	pub fn init() -> ThemesStore {
 		let themes_dir = {
-			let Some(data) = dirs::state_dir() else {
-				eprintln!("No Data directory could be found/accessed!");
-				panic!("Failed to find Data directory.")
-			};
+			let data = get_state_directory();
 			let app_data_dir = data.join(APP_DATA_DIR);
 
 			let themes_dir = app_data_dir.join("Themes");


### PR DESCRIPTION
Fix build for windows (and possibly mac. someone please test, or add a mac implementation)

The state directory is only available on Linux by default, which breaks builds on other platforms.
